### PR TITLE
fix the boost::network::uri::encode functions - Arithmetic shift problem

### DIFF
--- a/boost/network/uri/encode.hpp
+++ b/boost/network/uri/encode.hpp
@@ -115,7 +115,7 @@ void encode_char(CharT in, OutputIterator &out) {
       break;
     default:
       out++ = '%';
-      out++ = hex_to_letter(in >> 4);
+      out++ = hex_to_letter((in >> 4) & 0x0f);
       out++ = hex_to_letter(in & 0x0f);
       ;
   }


### PR DESCRIPTION
#1 
* 확인
 * 아스키코드가 아닌 문자인 경우 산술시프트에서 부호가 같이 삽입됨
* 수정
 * 비트마스크를 이용하여 부호를 버림