### PR TITLE
'boost::network::uri::encoded' 함수에 멀티바이트 문자열 테스트 추가

### DIFF
--- a/libs/network/test/uri/uri_encoding_test.cpp
+++ b/libs/network/test/uri/uri_encoding_test.cpp
@@ -29,3 +29,21 @@ BOOST_AUTO_TEST_CASE(decoding_test) {
   uri::decode(encoded, std::back_inserter(instance));
   BOOST_CHECK_EQUAL(instance, unencoded);
 }
+
+BOOST_AUTO_TEST_CASE(encoding_multibyte_test) {
+  const std::string unencoded("한글 테스트");
+  const std::string encoded("%ED%95%9C%EA%B8%80%20%ED%85%8C%EC%8A%A4%ED%8A%B8");
+
+  std::string instance;
+  uri::encode(unencoded, std::back_inserter(instance));
+  BOOST_CHECK_EQUAL(instance, encoded);
+}
+
+BOOST_AUTO_TEST_CASE(decoding_multibyte_test) {
+  const std::string unencoded("한글 테스트");
+  const std::string encoded("%ED%95%9C%EA%B8%80%20%ED%85%8C%EC%8A%A4%ED%8A%B8");
+
+  std::string instance;
+  uri::decode(encoded, std::back_inserter(instance));
+  BOOST_CHECK_EQUAL(instance, unencoded);
+}


### PR DESCRIPTION
#1
* case 이름
 * encoding_multibyte_test
 * decoding_multibyte_test
* 대상 문자열
 * unencoded: "한글 테스트"
 * encoded: "%ED%95%9C%EA%B8%80%20%ED%85%8C%EC%8A%A4%ED%8A%B8"
* 결과
 * 환경: ubuntu 15.04 x86_64, gcc 4.9.2
```
$ make test
Running tests...
/usr/bin/ctest --force-new-ctest-process 
Test project /home/cnagune/git/cpp-netlib
...
      Start  7: cpp-netlib-uri_encoding_test
 7/20 Test  #7: cpp-netlib-uri_encoding_test ........................   Passed    0.00 sec
...
```