### PR TITLE
Add OPENSSL_NO_SSL2 define for disabling SSLv2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 
 if (OPENSSL_FOUND)
     add_definitions(-DBOOST_NETWORK_ENABLE_HTTPS)
+    add_definitions(-DOPENSSL_NO_SSL2)
     include_directories(${OPENSSL_INCLUDE_DIR})
 endif()
 


### PR DESCRIPTION
travis(ubuntu)에서 빌드 실패 해결
```make
../external/lib/libcppnetlib-client-connections.a(client.cpp.o): In function `boost::asio::ssl::context::context(boost::asio::ssl::context_base::method)':
client.cpp:(.text._ZN5boost4asio3ssl7contextC2ENS1_12context_base6methodE[_ZN5boost4asio3ssl7contextC5ENS1_12context_base6methodE]+0x76): undefined reference to `SSLv2_method'
client.cpp:(.text._ZN5boost4asio3ssl7contextC2ENS1_12context_base6methodE[_ZN5boost4asio3ssl7contextC5ENS1_12context_base6methodE]+0x8f): undefined reference to `SSLv2_client_method'
client.cpp:(.text._ZN5boost4asio3ssl7contextC2ENS1_12context_base6methodE[_ZN5boost4asio3ssl7contextC5ENS1_12context_base6methodE]+0xa8): undefined reference to `SSLv2_server_method'
collect2: error: ld returned 1 exit status
```